### PR TITLE
Add ability to capture validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__
 .coverage
 .cache
 .python-version
+.idea

--- a/nbformat/__init__.py
+++ b/nbformat/__init__.py
@@ -48,7 +48,7 @@ NO_CONVERT = Sentinel('NO_CONVERT', __name__,
     """)
 
 
-def reads(s, as_version, **kwargs):
+def reads(s, as_version, capture_validation_error=None, **kwargs):
     """Read a notebook from a string and return the NotebookNode object as the given version.
 
     The string can contain a notebook of any version.
@@ -64,6 +64,10 @@ def reads(s, as_version, **kwargs):
         The version of the notebook format to return.
         The notebook will be converted, if necessary.
         Pass nbformat.NO_CONVERT to prevent conversion.
+    capture_validation_error : dict, optional
+        If provided, a key of "ValidationError" with a
+        value of the ValidationError instance will be added
+        to the dictionary.
 
     Returns
     -------
@@ -77,10 +81,12 @@ def reads(s, as_version, **kwargs):
         validate(nb)
     except ValidationError as e:
         get_logger().error("Notebook JSON is invalid: %s", e)
+        if isinstance(capture_validation_error, dict):
+            capture_validation_error['ValidationError'] = e
     return nb
 
 
-def writes(nb, version=NO_CONVERT, **kwargs):
+def writes(nb, version=NO_CONVERT, capture_validation_error=None, **kwargs):
     """Write a notebook to a string in a given format in the given nbformat version.
 
     Any notebook format errors will be logged.
@@ -93,6 +99,10 @@ def writes(nb, version=NO_CONVERT, **kwargs):
         The nbformat version to write.
         If unspecified, or specified as nbformat.NO_CONVERT,
         the notebook's own version will be used and no conversion performed.
+    capture_validation_error : dict, optional
+        If provided, a key of "ValidationError" with a
+        value of the ValidationError instance will be added
+        to the dictionary.
 
     Returns
     -------
@@ -107,10 +117,12 @@ def writes(nb, version=NO_CONVERT, **kwargs):
         validate(nb)
     except ValidationError as e:
         get_logger().error("Notebook JSON is invalid: %s", e)
+        if isinstance(capture_validation_error, dict):
+            capture_validation_error['ValidationError'] = e
     return versions[version].writes_json(nb, **kwargs)
 
 
-def read(fp, as_version, **kwargs):
+def read(fp, as_version, capture_validation_error=None, **kwargs):
     """Read a notebook from a file as a NotebookNode of the given version.
 
     The string can contain a notebook of any version.
@@ -127,6 +139,10 @@ def read(fp, as_version, **kwargs):
         The version of the notebook format to return.
         The notebook will be converted, if necessary.
         Pass nbformat.NO_CONVERT to prevent conversion.
+    capture_validation_error : dict, optional
+        If provided, a key of "ValidationError" with a
+        value of the ValidationError instance will be added
+        to the dictionary.
 
     Returns
     -------
@@ -138,12 +154,12 @@ def read(fp, as_version, **kwargs):
         buf = fp.read()
     except AttributeError:
         with io.open(fp, encoding='utf-8') as f:
-            return reads(f.read(), as_version, **kwargs)
+            return reads(f.read(), as_version, capture_validation_error, **kwargs)
 
-    return reads(buf, as_version, **kwargs)
+    return reads(buf, as_version, capture_validation_error, **kwargs)
 
 
-def write(nb, fp, version=NO_CONVERT, **kwargs):
+def write(nb, fp, version=NO_CONVERT, capture_validation_error=None, **kwargs):
     """Write a notebook to a file in a given nbformat version.
 
     The file-like object must accept unicode input.
@@ -160,8 +176,12 @@ def write(nb, fp, version=NO_CONVERT, **kwargs):
         If nb is not this version, it will be converted.
         If unspecified, or specified as nbformat.NO_CONVERT,
         the notebook's own version will be used and no conversion performed.
+    capture_validation_error : dict, optional
+        If provided, a key of "ValidationError" with a
+        value of the ValidationError instance will be added
+        to the dictionary.
     """
-    s = writes(nb, version, **kwargs)
+    s = writes(nb, version, capture_validation_error, **kwargs)
     if isinstance(s, bytes):
         s = s.decode('utf8')
 


### PR DESCRIPTION
This pull request stems from an issue discovered during Jupyter Server performance analysis in which it was learned that the [server is validating notebooks twice ](https://github.com/jupyter-server/jupyter_server/issues/312#issuecomment-697081912)(and on both read and write operations).  This appears to have been the case for the last 7 to 8 years (since the code resided in notebook).  I suspect this is based on history few are privy to, but this pull request attempts to rectify this in a (hopefully) acceptable manner.  Since the elimination of the redundant validation can improve performance by nearly 50%, this seems like an opportunity we should not ignore.

Because so many years have passed, I believe there are at least two backward-compatibility concerns that lead to this particular resolution.

1. The read/write calls do not inform the caller that the operation encountered a validation error.  As a result, the content (on read) is always returned, even in light of validation errors, which, today, are logged as errors.  This behavior also leads to the content always being written, even in light of validation errors.  (Of course, filesystem-related issues will raise appropriate exceptions, but all things being equal, the caller has no idea a validation issue is present.)
2. Applications wish to format their own validation error.  Jupyter Server (and notebook) used a subsequent (and unconditional) call to nbformat's `validate()` method, to capture the exception and produce an _application-friendly_ error message when validation issues are encountered.

This change adds an optional dictionary-valued parameter (`capture_validation_error`) that applications can pass to capture the `ValidationError` instance for use by the calling application. If the parameter is non-None and a dictionary instance, a validation error will be added into the dictionary under the key `'ValidationError'` while the corresponding value will contain the `ValidationError` instance.  This would allow applications that make an additional call to `validate()` to remove the second call since they have both their content (on reads) and the `ValidationError` instance when validation issues are present.

## Alternative approaches
1. One approach would be to add an optional boolean parameter that _skips_ validation on the read/write methods, leaving actual validation up to the application.  Since today's read/write code leaves no indication that a validation error was encountered, this approach would work as well.  However, given that read/write methods already include validation, it does require an additional method call and feels a bit clunky.
2. Another approach would be to raise `ValidationError` when it occurs, which also allows the application to produce a friendly message, but will prevent the return of content (on reads) and persistence of content (on writes) - that is assumed behavior today.

There may be other solutions, but I think we should do something as this is the kind of low-hanging fruit that performance-sensitive folks live for. :smile: